### PR TITLE
[FIX] map_async hack is not python2/3 compatible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ floop
 =====
 
 
-.. image:: http://docs.forward-loop.com/floopcli/dev/status/build-status.png
-   :target: http://docs.forward-loop.com/floopcli/dev/status/build-status.html
+.. image:: http://docs.forward-loop.com/floopcli/master/status/build-status.png
+   :target: http://docs.forward-loop.com/floopcli/master/status/build-status.html
 
 Note: this repository is in the alpha development stage. We recommend you always pull or upgrade to the latest version. 
 

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ floop
 =====
 
 
-.. image:: http://docs.forward-loop.com/floopcli/master/status/build-status.png
-   :target: http://docs.forward-loop.com/floopcli/master/status/build-status.html
+.. image:: http://docs.forward-loop.com/floopcli/dev/0.0.1a3/build-status.png
+   :target: http://docs.forward-loop.com/floopcli/0.0.1a3/status/build-status.html
 
 Note: this repository is in the alpha development stage. We recommend you always pull or upgrade to the latest version. 
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ floop
 =====
 
 
-.. image:: http://docs.forward-loop.com/floopcli/dev/build-status.png
+.. image:: http://docs.forward-loop.com/floopcli/dev/status/build-status.png
    :target: http://docs.forward-loop.com/floopcli/dev/status/build-status.html
 
 Note: this repository is in the alpha development stage. We recommend you always pull or upgrade to the latest version. 

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ floop
 =====
 
 
-.. image:: http://docs.forward-loop.com/floopcli/dev/0.0.1a3/build-status.png
-   :target: http://docs.forward-loop.com/floopcli/0.0.1a3/status/build-status.html
+.. image:: http://docs.forward-loop.com/floopcli/dev/build-status.png
+   :target: http://docs.forward-loop.com/floopcli/dev/status/build-status.html
 
 Note: this repository is in the alpha development stage. We recommend you always pull or upgrade to the latest version. 
 

--- a/floopcli/cli.py
+++ b/floopcli/cli.py
@@ -265,12 +265,11 @@ class FloopCLI(object):
         '''
         pool = Pool()
         try:
-            # handle interrupt with python 2 hack (python bug 8296)
-            # don't block, timeout after the sun supernovas
-            pool.map_async(func, self.cores).get(1e100)
+            # handle interrupt with python 2 hack (python 2: bug 8296)
+            # don't block, timeout for the largest 64 bit signed integer (python 3)
+            pool.map_async(func, self.cores).get(9223372036)
         except KeyboardInterrupt:
             pool.terminate()
-            pass
 
     def config(self): # type: (FloopCLIType) -> None
         '''


### PR DESCRIPTION
Previously the pool.map_async get method hack supported KeyboardInterrupt on Python 2. However, the get value of 1e100 caused an OverflowError in Python 3. This pull request reduces the get timeout from 1e100 to the largest 64 bit signed integer, so parallel methods work in Python 3.