### PR TITLE
[UPD] build_file, test_file in config; kill parent and child processes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ floop
 =====
 
 
-.. image:: http://docs.forward-loop.com/floopcli/0.0.1a4/status/build-status.png
-   :target: http://docs.forward-loop.com/floopcli/0.0.1a4/status/build-status.html
+.. image:: http://docs.forward-loop.com/floopcli/dev/status/build-status.png
+   :target: http://docs.forward-loop.com/floopcli/dev/status/build-status.html
 
 Note: this repository is in the alpha development stage. We recommend you always pull or upgrade to the latest version. 
 

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ floop
 =====
 
 
-.. image:: http://docs.forward-loop.com/floopcli/master/status/build-status.png
-   :target: http://docs.forward-loop.com/floopcli/master/status/build-status.html
+.. image:: http://docs.forward-loop.com/floopcli/0.0.1a4/status/build-status.png
+   :target: http://docs.forward-loop.com/floopcli/0.0.1a4/status/build-status.html
 
 Note: this repository is in the alpha development stage. We recommend you always pull or upgrade to the latest version. 
 

--- a/docs/source/intro/best.rst
+++ b/docs/source/intro/best.rst
@@ -46,10 +46,26 @@ Now you can unplug power to your target device, copy the target operating system
 Applications and Dockerfiles
 ============================
 
-Use *library* Docker Images
----------------------------
-When working with ARM targets, you should always base your **Dockerfile.test** and **Dockerfile** environments on images from the `Docker Hub Library <https://hub.docker.com/u/library/>`_. These images `work across platforms <https://blog.docker.com/2017/09/docker-official-images-now-multi-platform/>`_, including x86 and ARM. It is not guaranteed that other base images will build correctly on ARM hardware. In practice, this means that all Dockerfiles should start with:
-::
-    FROM library/...
+Use Docker Images for Your Version of ARM
+-----------------------------------------
+When working with ARM targets, you should always base your **Dockerfile.test** and **Dockerfile** environments on images that match the ARM version of your target hardware operating system. 
 
-If you need a language or environment that is not provided as a *library* image, you can often build one yourself by installing on a base image such as **library/debian**.
+.. tabs::
+
+  .. tab:: ARMv7
+
+    This works for Armbian on Orange Pi.
+
+    For ARMv7, you should use images from the `Docker Hub Library <https://hub.docker.com/u/library/>`_. These images `work across platforms <https://blog.docker.com/2017/09/docker-official-images-now-multi-platform/>`_, including x86 and ARMv7. It is not guaranteed that other base images will build correctly on ARMv7 hardware. In practice, this means that all Dockerfiles for all ARMv7 devices should start with:
+    ::
+        FROM library/...
+
+    If you need a language or environment that is not provided as a *library* image, you can often build one yourself by installing on a base image such as **library/debian**.
+
+  .. tab:: ARMv6
+
+    This works for Raspbian on Raspberry Pi.
+
+    For ARMv6 images, you should use images from the `arm32v6 Library <https://hub.docker.com/u/arm32v6/>`_. These images only work for ARMv6 devices. In practice, this means that all Dockerfiles for all ARMv7 devices should start with:
+    ::
+        FROM arm32v6/...

--- a/docs/source/intro/hello.rst
+++ b/docs/source/intro/hello.rst
@@ -281,11 +281,11 @@ This will generate a default configuration called **floop.json**.
 This configuration is based on the following default values (this is a Python dictionary that gets written to JSON):
 
 .. literalinclude:: ../../../floopcli/config.py
-    :lines: 10-32
+    :lines: 10-35
 
 :subscript:`(Note: The calls to the *which* function automatically set the path of docker-machine and rsync as they are installed on your system. If needed, you can edit floop.json to set the paths to each binary dependency. This may be useful if you need to use a different version of docker-machine or rsync than the default version for your system.)`
 
-From this we can describe the default configuration in plain language. All groups use the same rsync and docker-machine binaries. We define one group called *group0*. All cores in *group0* look to the *host_source* directory as their source code directory on the host. Within *group0* there is one core called *core0* that we can reach at its *address* using SSH access via the *user* and *host_key* on the host. When using floop, the *host_source* for *group0* will be pushed to *target_source* on *core0*.
+From this we can describe the default configuration in plain language. All groups use the same rsync and docker-machine binaries. We define one group called *group0*. All cores in *group0* look to the *host_source* directory as their source code directory on the host. Within *group0* there is one core called *core0* that we can reach at its *address* using SSH access via the *user* and *host_key* on the host. When using floop, the *host_source* for *group0* will be pushed to *target_source* on *core0*. When floop builds the the build and run environment on the target, it uses the *build_file* in the *host_source* folder, which appears as the *build_file* for the *target_source* on the target. The same is true for the *test_file* when floop builds the test environment. Both *build_file* and *test_file* are relative file names inside the *host_source* and the *target_source*.
 
 floop uses a compact configuration format that defines *default* key-values for groups and cores. A **group** is a collection of **cores**. A **core** runs an operating system. floop automatically flattens the configuration file as follows:
     - *default* key-values for **groups** become key-values for all groups
@@ -299,6 +299,8 @@ Applying the flattening procedure to the default configuration reveals that it d
     [
         {
             'host_source': './', 
+            'build_file' : 'Dockerfile',
+            'test_file' : 'Dockerfile.test',
             'core': 'core0', 
             'address': '192.168.1.100', 
             'host_docker_machine_bin': '/usr/local/bin/docker-machine', 
@@ -379,7 +381,7 @@ In order to build your code on all of your targets, you can run:
 
 :subscript:`(Note: build uses Docker under the hood, so all builds are cached. This means that first build usually takes much longer than subsequent builds.)``
 
-Optionally, you can add the *-v* flag to see that floop always pushes before a build then builds your run environment using the **Dockerfile** for your app. 
+Optionally, you can add the *-v* flag to see that floop always pushes before a build then builds your run environment using the *build_file* in the *target_source* for each core that builds your app. 
 
 8. Test Code on Targets
 =======================
@@ -388,7 +390,7 @@ You can run your test environment for your app by running:
 
   floop test
 
-Optionally, you can add the *-v* flag to see that floop always pushes and always builds and runs the test environment using the **Dockerfile.test** for your app.  
+Optionally, you can add the *-v* flag to see that floop always pushes and always builds and runs the test environment using the *test_file* in the *target_source* for each core that tests your app your app.  
 
 You should see your tests run on all targets.
 
@@ -399,7 +401,7 @@ You can run your run environment for your app by running:
 
   floop run 
 
-Optionally, you can add the *-v* flag to see that floop always pushes and always builds and runs the run environment using the **Dockerfile** for your app.  
+Optionally, you can add the *-v* flag to see that floop always pushes and always builds and runs the run environment using the *build_file* in the *target_source* for each core that builds your app.
 
 You should see all targets greet you with "Hello, World!"
 

--- a/docs/source/intro/os.rst
+++ b/docs/source/intro/os.rst
@@ -94,13 +94,33 @@ You should change *your.device.ip.address* to the IP address of your target devi
 
 If you see the line you added above to permit passwordless sudo, then your sudo configuration succeeded.
 
-If you are working with `Raspbian <https://www.raspbian.org/>`_, then you may need to perform the following additional step. You need to change the distribution ID from *raspbian* to *debian* so docker-machine recognizes that you are running a Debian-based operating system. You can do this by running the following command from your **host**:
-::
-  
-  ssh -i ~/.ssh/id_rsa \
-  floop@your.device.ip.address \
-  sed -ri 's/ID=raspbian/ID=debian/g' /etc/os-release
 
-Your operating system is now configured so that it can be used with floop. From your host, you can make a disk image of the configured operating system and copy that image and run it on other devices.
+Configuring Common Operating Systems
+------------------------------------
+The following section explains additional steps for how to configure common operating systems.
+
+.. tabs::
+
+  .. tab:: Armbian
+
+    There should be no additional steps to get started.
+
+  .. tab:: Raspbian
+
+    If you are working with `Raspbian <https://www.raspbian.org/>`_, then you may need to perform the following additional steps.
+    
+    Install Docker. Currently, Docker Machine cannot install Docker on Raspbian, so you need to install it on the target directly. You can do this by running the following on your **target**:
+    ::
+
+      curl -fsSL get.docker.com | sh
+    
+    You then need to change the distribution ID from *raspbian* to *debian* so docker-machine recognizes that you are running a Debian-based operating system. You can do this by running the following command from your **host**:
+    ::
+      
+      ssh -i ~/.ssh/id_rsa \
+      floop@your.device.ip.address \
+      sed -ri 's/ID=raspbian/ID=debian/g' /etc/os-release
+
+    Your operating system is now configured so that it can be used with floop. From your host, you can make a disk image of the configured operating system and copy that image and run it on other devices.
 
 For more options (not requirements) for configuring your target operating system, check the :doc:`best`

--- a/floopcli/cli.py
+++ b/floopcli/cli.py
@@ -268,8 +268,9 @@ class FloopCLI(object):
             # handle interrupt with python 2 hack (python 2: bug 8296)
             # don't block, timeout for the largest 64 bit signed integer (python 3)
             pool.map_async(func, self.cores).get(9223372036)
-        except KeyboardInterrupt:
-            pool.terminate()
+        except (KeyboardInterrupt, Exception):
+            pool.close()
+            pool.join()
 
     def config(self): # type: (FloopCLIType) -> None
         '''

--- a/floopcli/cli.py
+++ b/floopcli/cli.py
@@ -268,9 +268,10 @@ class FloopCLI(object):
             # handle interrupt with python 2 hack (python 2: bug 8296)
             # don't block, timeout for the largest 64 bit signed integer (python 3)
             pool.map_async(func, self.cores).get(9223372036)
-        except (KeyboardInterrupt, Exception):
+        except (KeyboardInterrupt, Exception) as e:
             pool.close()
             pool.join()
+            raise e
 
     def config(self): # type: (FloopCLIType) -> None
         '''

--- a/floopcli/config.py
+++ b/floopcli/config.py
@@ -18,7 +18,9 @@ _FLOOP_CONFIG_DEFAULT_CONFIGURATION = {
         'group0' :{
             'cores' : {
                 'default': {
-                    'host_source' : './'
+                    'host_source' : './',
+                    'build_file' : 'Dockerfile',
+                    'test_file' : 'Dockerfile.test'
                 },
                 'core0' : {
                     'target_source' : '/home/floop/floop/',

--- a/floopcli/iot/core.py
+++ b/floopcli/iot/core.py
@@ -466,7 +466,7 @@ def build(core, check=True): # type: (Core, bool) -> None
     try:
         out = core.run_ssh_command(meta_build_command, check=check, verbose=verbose())
         __log(core, 'info', out)
-    except SystemCallException as e:
+    except (SystemCallException, CoreBuildException) as e:
         __log(core, 'error', repr(e))
         raise CoreBuildException(repr(e))
 

--- a/floopcli/iot/core.py
+++ b/floopcli/iot/core.py
@@ -129,7 +129,7 @@ class Core(object):
             core,
             user,
             **kwargs): 
-        # type: (str, str, str, str, str, str, str, str, str, str, str) -> None
+        # type: (str, str, str, str, str, str, str, str, str, str, str, str, str) -> None
 
         self.address = address
         '''Core IP address (reachable by SSH)'''

--- a/floopcli/iot/core.py
+++ b/floopcli/iot/core.py
@@ -376,7 +376,7 @@ def create(core, check=True, timeout=120): # type: (Core, bool, int) -> None
             'pwd' check failed
     '''
     def timeout_handler(signum, frame): #type: ignore
-        raise SystemCallException('Create core timed out')
+        raise CoreCreateException('Create core timed out')
     create_command = '{} create --driver generic --generic-ip-address {} --generic-ssh-port {} --generic-ssh-user {} --generic-ssh-key {} --engine-storage-driver overlay {}'.format(
         core.host_docker_machine_bin,
         core.address, 

--- a/floopcli/iot/core.py
+++ b/floopcli/iot/core.py
@@ -357,7 +357,7 @@ def __log(core, level, message): # type: (Core, str, str) -> None
 ###  parallelizable methods that act on Core objects
 # these functions are pickle-able, but class methods are NOT
 # so these functions can be passed to multiprocessing.Pool
-def create(core, check=True, timeout=120): # type: (Core, bool, int) -> None
+def create(core, check=True, timeout=240): # type: (Core, bool, int) -> None
     '''
     Parallelizable; create new docker-machine on target core
 

--- a/floopcli/test/fixture.py
+++ b/floopcli/test/fixture.py
@@ -17,10 +17,12 @@ FLOOP_TEST_CONFIG_FILE = './floop.json'
 
 FLOOP_TEST_CONFIG = _FLOOP_CONFIG_DEFAULT_CONFIGURATION
 
+# you need to pass FLOOP_CLOUD_CORES as an env variable
 _TEST_FLOOP_CLOUD_CORES = environ.get('FLOOP_CLOUD_CORES')
 
 _TEST_CORE_NAME = 'core0' 
 if _TEST_FLOOP_CLOUD_CORES is not None:
+    # you need to pass FLOOP_CLOUD_CORES as an env variable
     _TEST_CORE_NAME = _TEST_FLOOP_CLOUD_CORES.split(':')[0]
 
 _DEVICE_TEST_SRC_DIRECTORY = '{}/src/'.format(dirname(
@@ -85,6 +87,8 @@ def fixture_valid_core_config(request): # type: (pytest.FixtureRequest) -> Dict[
                 'group' : 'group0',
                 'host_docker_machine_bin' : fixture_docker_machine_bin(), 
                 'host_key' :  '~/.ssh/id_rsa', 
+                'build_file' : 'Dockerfile',
+                'test_file' : 'Dockerfile.test',
                 'host_rsync_bin' : fixture_rsync_bin(),
                 'host_source' : fixture_valid_src_directory(request),
                 'core' : _TEST_CORE_NAME,
@@ -96,6 +100,8 @@ def fixture_valid_core_config(request): # type: (pytest.FixtureRequest) -> Dict[
                 'group' : 'group0',
                 'host_docker_machine_bin' : fixture_docker_machine_bin(), 
                 'host_key' :  '~/.ssh/id_rsa', 
+                'build_file' : 'Dockerfile',
+                'test_file' : 'Dockerfile.test',
                 'host_rsync_bin' : fixture_rsync_bin(),
                 'host_source' : fixture_valid_src_directory(request),
                 'core' : _TEST_CORE_NAME, 

--- a/floopcli/test/fixture.py
+++ b/floopcli/test/fixture.py
@@ -223,7 +223,7 @@ def fixture_failing_buildfile(request): # type: (pytest.FixtureRequest) -> str
     src_dir = fixture_valid_src_directory(request)
     buildfile = '{}/Dockerfile'.format(_DEVICE_TEST_SRC_DIRECTORY)
     buildfile_contents = '''FROM busybox:latest
-RUN apt-get update''' 
+RUN cp''' 
     with open(buildfile, 'w') as bf:
         bf.write(buildfile_contents)
     return src_dir

--- a/floopcli/test/floop_test/cli_test.py
+++ b/floopcli/test/floop_test/cli_test.py
@@ -68,9 +68,9 @@ def fixture_malformed_floop_configs(request):
 
 def test_cli_build_fail_fails(fixture_valid_config_file, fixture_failing_buildfile):
     with pytest.raises(SystemCallException):
-        syscall(
+        print(syscall(
             'floop -c {} build'.format(
-                fixture_valid_config_file), check=True)
+                fixture_valid_config_file), check=True))
 
 def test_cli_run_fail_fails(fixture_valid_config_file, fixture_failing_runfile):
     with pytest.raises(SystemCallException):

--- a/floopcli/util/syscall.py
+++ b/floopcli/util/syscall.py
@@ -51,5 +51,6 @@ def syscall(command, check=False, # type: ignore
             if process.returncode != 0:
                 raise SystemCallException(err)
         return (out, err)
-    except (KeyboardInterrupt, Exception):
+    except (KeyboardInterrupt, SystemCallException) as e:
         process.kill()
+        raise e

--- a/floopcli/util/syscall.py
+++ b/floopcli/util/syscall.py
@@ -20,7 +20,7 @@ def syscall(command, check=False,
         check (bool):
             whether to check for non-zero exit code
         verbose (bool):
-            if True, prints command output to stdout
+            if True, streams command output to stdout
 
     Raises:
         :py:class:`floopcli.util.SystemCallException`:
@@ -31,12 +31,14 @@ def syscall(command, check=False,
             tuple of command output to (stdout, stderr)
     '''
     command_ = split(command)
-    process = subprocess.Popen(command_, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(command_, stdout=subprocess.PIPE)
     out = ''
-    for line in process.stdout: # type: ignore
+    for line in iter(process.stdout.readline, b''): # type: ignore
         line = line.decode('utf-8')
         out += line
         if verbose:
+            # this sits below the logger, so removing the console handler 
+            # would not silence this print
             stdout.write(line)
     _, err = process.communicate()
     if err is not None:

--- a/floopcli/util/syscall.py
+++ b/floopcli/util/syscall.py
@@ -32,21 +32,24 @@ def syscall(command, check=False, # type: ignore
             tuple of command output to (stdout, stderr)
     '''
     command_ = split(command)
-    process = subprocess.Popen(command_, stdout=subprocess.PIPE)
-    out = ''
-    # Python 2: str to bytes?
-    # Python 3: unicode to str?
-    for line in iter(process.stdout.readline, b''): # type: ignore
-        line = line.decode('utf-8')
-        out += line
-        if verbose:
-            # this sits below the logger, so removing the console handler 
-            # would not silence this print
-            stdout.write(line)
-    _, err = process.communicate()
-    if err is not None:
-        err = err.decode('utf-8')
-    if check:
-        if process.returncode != 0:
-            raise SystemCallException(err)
-    return (out, err)
+    try:
+        process = subprocess.Popen(command_, stdout=subprocess.PIPE)
+        out = ''
+        # Python 2: str to bytes?
+        # Python 3: unicode to str?
+        for line in iter(process.stdout.readline, b''): # type: ignore
+            line = line.decode('utf-8')
+            out += line
+            if verbose:
+                # this sits below the logger, so removing the console handler 
+                # would not silence this print
+                stdout.write(line)
+        _, err = process.communicate()
+        if err is not None:
+            err = err.decode('utf-8')
+        if check:
+            if process.returncode != 0:
+                raise SystemCallException(err)
+        return (out, err)
+    except (KeyboardInterrupt, Exception):
+        process.kill()

--- a/floopcli/util/syscall.py
+++ b/floopcli/util/syscall.py
@@ -9,8 +9,9 @@ class SystemCallException(Exception):
     '''
     pass
 
-def syscall(command, check=False,
-        verbose=False): # type: (str, bool, bool) -> Tuple[str, str] 
+# TODO: figure out consistent Python 2/3 typing
+def syscall(command, check=False, # type: ignore
+        verbose=False): 
     '''
     Call system to run system command
 
@@ -33,6 +34,8 @@ def syscall(command, check=False,
     command_ = split(command)
     process = subprocess.Popen(command_, stdout=subprocess.PIPE)
     out = ''
+    # Python 2: str to bytes?
+    # Python 3: unicode to str?
     for line in iter(process.stdout.readline, b''): # type: ignore
         line = line.decode('utf-8')
         out += line

--- a/floopcli/util/syscall.py
+++ b/floopcli/util/syscall.py
@@ -52,5 +52,8 @@ def syscall(command, check=False, # type: ignore
                 raise SystemCallException(err)
         return (out, err)
     except (KeyboardInterrupt, SystemCallException) as e:
-        process.kill()
+        try:
+            process.kill()
+        except OSError:
+            pass
         raise e

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras = {
 
 setup(
     name='floopcli',
-    version='0.0.1a3',
+    version='0.0.1a4',
     description='sensor development and testing tools',
     long_description=long_description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
This request changes the floop.json default configuration by adding build_file and test_file keys to allow for different Dockerfiles for the same host_source. This is a backwards incompatible configuration API change.

Additionally, all CLI methods that communicate in parallel with cores should now properly kill parent and child processes and communicate error information between processes. Basically, when one process in a pool fails, all processes are immediately killed, and the error is communicated to the CLI control flow. This should be a safe change because of the idempotency of both docker-machine and rsync.